### PR TITLE
feat: list tenants/endpoints, new gateway events, art improvements

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/DKE-Data/agrirouter-sdk-go/internal/oapi"
+	"github.com/google/uuid"
 )
 
 var (
@@ -143,6 +144,41 @@ func (c *Client) SendMessages(
 	}
 
 	return fmt.Errorf("%w: unexpected status code %d, body: %s", ErrFailedStatusCode, res.StatusCode(), string(res.Body))
+}
+
+// ListAuthorizedTenants returns all tenants for which the current application
+// has an existing authorization, together with the related endpoints known
+// for each tenant.
+//
+// This is intended as the primary global synchronization endpoint, for example
+// when an application starts or recovers and needs to rebuild its complete
+// tenant state.
+func (c *Client) ListAuthorizedTenants(ctx context.Context) ([]TenantInfo, error) {
+	res, err := c.oapiClient.ListAuthorizedTenantsWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrAPICallFailed, err)
+	}
+	if res.JSON200 != nil {
+		return res.JSON200.Tenants, nil
+	}
+	return nil, fmt.Errorf("%w: %w", ErrAPICallFailed, httpResponseToErr(res.HTTPResponse, res.Body))
+}
+
+// ListTenantEndpoints returns the current list of endpoints in a single tenant
+// together with their capability information.
+//
+// For endpoints owned by the authorized application, the result also includes
+// route-derived maps describing which endpoints they can send to and receive
+// from for each message type.
+func (c *Client) ListTenantEndpoints(ctx context.Context, tenantID uuid.UUID) ([]TenantEndpointInfo, error) {
+	res, err := c.oapiClient.ListTenantEndpointsWithResponse(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrAPICallFailed, err)
+	}
+	if res.JSON200 != nil {
+		return res.JSON200.Endpoints, nil
+	}
+	return nil, fmt.Errorf("%w: %w", ErrAPICallFailed, httpResponseToErr(res.HTTPResponse, res.Body))
 }
 
 // ConfirmMessages confirms that messages have been received and processed.

--- a/events.go
+++ b/events.go
@@ -31,6 +31,251 @@ var ErrToCloseResponseBody = errors.New("failed to close response body")
 // ErrMissingPayload is returned when agrirouter returned no embedded payload with message nor a payload URI.
 var ErrMissingPayload = errors.New("missing payload: no embedded payload and no payload URI")
 
+// EventType identifies a kind of event sent by the agrirouter events stream.
+type EventType = internal_models.ReceiveEventsParamsTypes
+
+// Event types accepted by [Client.ReceiveEvents] and emitted by the events stream.
+const (
+	EventTypeMessageReceived      = internal_models.MESSAGERECEIVED
+	EventTypeFileReceived         = internal_models.FILERECEIVED
+	EventTypeEndpointDeleted      = internal_models.ENDPOINTDELETED
+	EventTypeEndpointsListChanged = internal_models.ENDPOINTSLISTCHANGED
+	EventTypeAuthorizationAdded   = internal_models.AUTHORIZATIONADDED
+	EventTypeAuthorizationRevoked = internal_models.AUTHORIZATIONREVOKED
+)
+
+// EventHandlers groups optional per-event-type callbacks for [Client.ReceiveEvents].
+//
+// Only handlers that are set will be invoked; events whose handler is nil are
+// silently dropped after parsing. Note that [Client.ReceiveEvents] does not
+// itself filter on handler presence — events are filtered server-side via the
+// types argument. If a handler is nil for an event type that was requested,
+// matching events still arrive but are discarded.
+type EventHandlers struct {
+	OnMessage              MessageHandler
+	OnFile                 func(ctx context.Context, file *File)
+	OnEndpointDeleted      EndpointDeletionHandler
+	OnEndpointsListChanged func(ctx context.Context, event *EndpointsListChangedEventData)
+	OnAuthorizationAdded   func(ctx context.Context, event *AuthorizationAddedEventData)
+	OnAuthorizationRevoked func(ctx context.Context, event *AuthorizationRevokedEventData)
+}
+
+// ReceiveEvents listens for events from the agrirouter API and dispatches each
+// received event to the matching handler in handlers.
+//
+// types restricts which event types the server streams. If types is empty or
+// nil, the server streams all supported event types.
+//
+// This function blocks until the context is canceled or an error occurs.
+// It is recommended to run this function in a separate goroutine.
+func (c *Client) ReceiveEvents(
+	ctx context.Context,
+	types []EventType,
+	handlers EventHandlers,
+	errorHandler func(err error),
+) error {
+	var typesParam *[]internal_models.ReceiveEventsParamsTypes
+	if len(types) > 0 {
+		t := append([]internal_models.ReceiveEventsParamsTypes(nil), types...)
+		typesParam = &t
+	}
+	return c.receiveAndHandleEvents(ctx, typesParam, func(event internal_models.GenericEventData) {
+		c.dispatchEvent(ctx, event, handlers, errorHandler)
+	}, errorHandler)
+}
+
+func (c *Client) dispatchEvent(
+	ctx context.Context,
+	event internal_models.GenericEventData,
+	handlers EventHandlers,
+	errorHandler func(err error),
+) {
+	discriminator, err := event.Discriminator()
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	switch EventType(discriminator) {
+	case EventTypeMessageReceived:
+		c.dispatchMessageReceived(ctx, event, handlers.OnMessage, errorHandler)
+	case EventTypeFileReceived:
+		c.dispatchFileReceived(ctx, event, handlers.OnFile, errorHandler)
+	case EventTypeEndpointDeleted:
+		dispatchEndpointDeleted(ctx, event, handlers.OnEndpointDeleted, errorHandler)
+	case EventTypeEndpointsListChanged:
+		dispatchEndpointsListChanged(ctx, event, handlers.OnEndpointsListChanged, errorHandler)
+	case EventTypeAuthorizationAdded:
+		dispatchAuthorizationAdded(ctx, event, handlers.OnAuthorizationAdded, errorHandler)
+	case EventTypeAuthorizationRevoked:
+		dispatchAuthorizationRevoked(ctx, event, handlers.OnAuthorizationRevoked, errorHandler)
+	}
+}
+
+func (c *Client) dispatchMessageReceived(
+	ctx context.Context,
+	event internal_models.GenericEventData,
+	handler MessageHandler,
+	errorHandler func(err error),
+) {
+	if handler == nil {
+		return
+	}
+	data, err := event.AsMessageReceivedEventData()
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	message, err := c.messageFromEventData(ctx, &data, errorHandler)
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	handler(ctx, message)
+}
+
+func (c *Client) dispatchFileReceived(
+	ctx context.Context,
+	event internal_models.GenericEventData,
+	handler func(ctx context.Context, file *File),
+	errorHandler func(err error),
+) {
+	if handler == nil {
+		return
+	}
+	data, err := event.AsFileReceivedEventData()
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	file, err := c.fileFromEventData(ctx, &data, errorHandler)
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	handler(ctx, file)
+}
+
+func dispatchEndpointDeleted(
+	ctx context.Context,
+	event internal_models.GenericEventData,
+	handler EndpointDeletionHandler,
+	errorHandler func(err error),
+) {
+	if handler == nil {
+		return
+	}
+	data, err := event.AsEndpointDeletedEventData()
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	handler(ctx, &DeletedEndpoint{ID: data.Id, ExternalID: data.ExternalId})
+}
+
+func dispatchEndpointsListChanged(
+	ctx context.Context,
+	event internal_models.GenericEventData,
+	handler func(ctx context.Context, event *EndpointsListChangedEventData),
+	errorHandler func(err error),
+) {
+	if handler == nil {
+		return
+	}
+	data, err := event.AsEndpointsListChangedEventData()
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	handler(ctx, &data)
+}
+
+func dispatchAuthorizationAdded(
+	ctx context.Context,
+	event internal_models.GenericEventData,
+	handler func(ctx context.Context, event *AuthorizationAddedEventData),
+	errorHandler func(err error),
+) {
+	if handler == nil {
+		return
+	}
+	data, err := event.AsAuthorizationAddedEventData()
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	handler(ctx, &data)
+}
+
+func dispatchAuthorizationRevoked(
+	ctx context.Context,
+	event internal_models.GenericEventData,
+	handler func(ctx context.Context, event *AuthorizationRevokedEventData),
+	errorHandler func(err error),
+) {
+	if handler == nil {
+		return
+	}
+	data, err := event.AsAuthorizationRevokedEventData()
+	if err != nil {
+		errorHandler(err)
+		return
+	}
+	handler(ctx, &data)
+}
+
+func (c *Client) messageFromEventData(
+	ctx context.Context,
+	data *internal_models.MessageReceivedEventData,
+	errorHandler func(err error),
+) (*Message, error) {
+	message := &Message{
+		ID:                  data.Id,
+		MessageType:         data.MessageType,
+		AppMessageID:        data.AppMessageId,
+		ReceivingEndpointID: data.ReceivingEndpointId,
+		Filename:            data.Filename,
+		TenantID:            data.TenantId,
+		TeamsetContextID:    data.TeamsetContextId,
+	}
+	if data.PayloadUri == nil {
+		if data.Payload == nil {
+			return nil, ErrMissingPayload
+		}
+		message.Payload = *data.Payload
+		return message, nil
+	}
+	payload, err := c.fetchMessagePayload(ctx, *data.PayloadUri, errorHandler)
+	if err != nil {
+		return nil, err
+	}
+	message.Payload = payload
+	return message, nil
+}
+
+func (c *Client) fileFromEventData(
+	ctx context.Context,
+	data *internal_models.FileReceivedEventData,
+	errorHandler func(err error),
+) (*File, error) {
+	if data.PayloadUri == nil {
+		return nil, ErrMissingPayload
+	}
+	payload, err := c.fetchFilePayload(ctx, *data.PayloadUri, errorHandler)
+	if err != nil {
+		return nil, err
+	}
+	return &File{
+		Payload:             payload,
+		ReceivingEndpointID: data.ReceivingEndpointId,
+		Filename:            data.Filename,
+		MessageType:         data.MessageType,
+		Size:                data.Size,
+		MessageIDs:          data.MessageIds,
+		TenantID:            data.TenantId,
+		TeamsetContextID:    data.TeamsetContextId,
+	}, nil
+}
+
 // Message represents a message received from agrirouter.
 type Message struct {
 	ID                  uuid.UUID // ID is the agrirouter message ID, generated by agrirouter
@@ -78,6 +323,75 @@ func (c *Client) ReceiveEndpointDeletedEvents(
 			ID:         deletedEvent.Id,
 			ExternalID: deletedEvent.ExternalId,
 		})
+	}, errorHandler)
+}
+
+// ReceiveEndpointsListChangedEvents listens for ENDPOINTS_LIST_CHANGED events from the
+// agrirouter API and calls the provided handler for each received event.
+//
+// The event carries the complete current list of endpoints visible to the
+// application in the affected tenant.
+//
+// This function blocks until the context is canceled or an error occurs.
+// It is recommended to run this function in a separate goroutine.
+func (c *Client) ReceiveEndpointsListChangedEvents(
+	ctx context.Context,
+	handler func(ctx context.Context, event *EndpointsListChangedEventData),
+	errorHandler func(err error),
+) error {
+	return c.receiveAndHandleEvents(ctx, &[]internal_models.ReceiveEventsParamsTypes{
+		internal_models.ENDPOINTSLISTCHANGED,
+	}, func(event internal_models.GenericEventData) {
+		data, err := event.AsEndpointsListChangedEventData()
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		handler(ctx, &data)
+	}, errorHandler)
+}
+
+// ReceiveAuthorizationAddedEvents listens for AUTHORIZATION_ADDED events from the
+// agrirouter API and calls the provided handler for each received event.
+//
+// This function blocks until the context is canceled or an error occurs.
+// It is recommended to run this function in a separate goroutine.
+func (c *Client) ReceiveAuthorizationAddedEvents(
+	ctx context.Context,
+	handler func(ctx context.Context, event *AuthorizationAddedEventData),
+	errorHandler func(err error),
+) error {
+	return c.receiveAndHandleEvents(ctx, &[]internal_models.ReceiveEventsParamsTypes{
+		internal_models.AUTHORIZATIONADDED,
+	}, func(event internal_models.GenericEventData) {
+		data, err := event.AsAuthorizationAddedEventData()
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		handler(ctx, &data)
+	}, errorHandler)
+}
+
+// ReceiveAuthorizationRevokedEvents listens for AUTHORIZATION_REVOKED events from the
+// agrirouter API and calls the provided handler for each received event.
+//
+// This function blocks until the context is canceled or an error occurs.
+// It is recommended to run this function in a separate goroutine.
+func (c *Client) ReceiveAuthorizationRevokedEvents(
+	ctx context.Context,
+	handler func(ctx context.Context, event *AuthorizationRevokedEventData),
+	errorHandler func(err error),
+) error {
+	return c.receiveAndHandleEvents(ctx, &[]internal_models.ReceiveEventsParamsTypes{
+		internal_models.AUTHORIZATIONREVOKED,
+	}, func(event internal_models.GenericEventData) {
+		data, err := event.AsAuthorizationRevokedEventData()
+		if err != nil {
+			errorHandler(err)
+			return
+		}
+		handler(ctx, &data)
 	}, errorHandler)
 }
 

--- a/examples/art/.env.example
+++ b/examples/art/.env.example
@@ -1,0 +1,24 @@
+# Copy to .env and fill in. Existing process environment variables take
+# precedence over values in this file.
+
+# OAuth 2.0 client credentials for the agrirouter application. Required.
+AGRIROUTER_OAUTH_CLIENT_ID=
+AGRIROUTER_OAUTH_CLIENT_SECRET=
+
+# Default tenant UUID, used when --tenant-id / -t is not passed.
+ART_TENANT_ID=
+
+# Default application UUID, used when --application-id is not passed.
+ART_APPLICATION_ID=
+
+# Default software-version UUID, used when --software-version-id is not passed.
+ART_SOFTWARE_VERSION_ID=
+
+# Optional: override the agrirouter API base URL. Defaults to
+# https://api.qa.agrirouter.farm. Use this to point at a local gateway,
+# e.g. http://localhost:8081.
+#ART_API_URL=
+
+# Optional: override the OAuth 2.0 token URL. Defaults to
+# https://oauth.qa.agrirouter.farm/token.
+#ART_OAUTH_TOKEN_URL=

--- a/examples/art/.gitignore
+++ b/examples/art/.gitignore
@@ -1,1 +1,2 @@
 secret
+.env

--- a/examples/art/README.md
+++ b/examples/art/README.md
@@ -1,0 +1,136 @@
+# art — agrirouter G4 CLI
+
+`art` is a small command-line tool built on top of [`agrirouter-sdk-go`](../..)
+that exercises the agrirouter G4 API. It is useful as a working example of
+the SDK and as a debugging client during development.
+
+## Build & run
+
+```bash
+# from this directory (examples/art/)
+go build -o art .
+./art --help
+
+# or run directly
+go run . --help
+```
+
+## Authentication
+
+`art` authenticates against agrirouter using the OAuth 2.0 client-credentials
+flow. Set the client ID and secret in the environment before running any
+command that talks to the API:
+
+```bash
+export AGRIROUTER_OAUTH_CLIENT_ID=...
+export AGRIROUTER_OAUTH_CLIENT_SECRET=...
+```
+
+The token endpoint and the API server URL default to QA
+(`https://oauth.qa.agrirouter.farm/token`, `https://api.qa.agrirouter.farm`).
+Override them via `ART_OAUTH_TOKEN_URL` and `ART_API_URL` to point at a
+different environment (e.g. a local gateway at `http://localhost:8081`).
+
+## Environment variables
+
+| Variable | Purpose | Used by |
+|---|---|---|
+| `AGRIROUTER_OAUTH_CLIENT_ID` | OAuth 2.0 client ID for the agrirouter application. Required. | All commands that call the API; `serve` also uses it to construct the user-facing authorize URL. |
+| `AGRIROUTER_OAUTH_CLIENT_SECRET` | OAuth 2.0 client secret. Required. | All commands that call the API. |
+| `ART_TENANT_ID` | Default tenant UUID, used when `--tenant-id` / `-t` is not passed. | `put-endpoint`, `delete-endpoint`, `send-messages`, `confirm-messages`, `list-tenant-endpoints`. The `repl` builtin `set-tenant <uuid>` updates this. |
+| `ART_APPLICATION_ID` | Default application UUID, used when `--application-id` is not passed. | `put-endpoint`, `serve`. |
+| `ART_SOFTWARE_VERSION_ID` | Default software-version UUID, used when `--software-version-id` is not passed. | `put-endpoint`, `serve`. |
+| `ART_API_URL` | Override the agrirouter API base URL. Defaults to `https://api.qa.agrirouter.farm`. Set to e.g. `http://localhost:8081` to test against a local gateway. | All API calls. |
+| `ART_OAUTH_TOKEN_URL` | Override the OAuth 2.0 token URL. Defaults to `https://oauth.qa.agrirouter.farm/token`. | Token acquisition. |
+
+For each `ART_*` variable the corresponding flag wins if it is provided;
+otherwise the env var is read. If neither is set and the value is required,
+the command errors out.
+
+### `.env` file
+
+On startup, `art` loads a `.env` file from the current working directory if
+one exists (using [`subosito/gotenv`](https://github.com/subosito/gotenv),
+the same parser viper uses). Variables already present in the process
+environment are **not** overridden, so real env vars always win over the
+file. A missing `.env` is silent.
+
+Copy `.env.example` to `.env` and fill in the values to get started:
+
+```bash
+cp .env.example .env
+$EDITOR .env
+```
+
+The `repl` subcommand expands `$ART_*` references (e.g. `$ART_TENANT_ID`) in
+its input lines before executing them and offers tab completion for any
+`ART_*` env var currently set.
+
+## Commands
+
+Run `art <command> --help` for full flag listings. At a glance:
+
+### Endpoint management
+- `put-endpoint` — create or update an endpoint by external ID.
+- `delete-endpoint` — delete an endpoint by external ID.
+- `list-authorized-tenants` (alias `lat`) — list all tenants the application
+  is authorized for, together with their visible endpoints.
+- `list-tenant-endpoints` (alias `lte`) — list endpoints of a single tenant,
+  including capabilities and route-derived send/receive maps for
+  application-owned endpoints.
+
+### Messaging
+- `send-messages` — send a message payload to agrirouter.
+- `receive-messages` — stream `MESSAGE_RECEIVED` events; optionally save
+  payloads to disk with `--save-payloads-to <dir>`.
+- `confirm-messages` — confirm one or more received messages.
+
+### Events
+- `receive-events` (alias `re`) — generic SSE listener. Without `--types`
+  receives every event kind; with `--types` (comma-separated or repeated)
+  filters server-side. Valid types: `MESSAGE_RECEIVED`, `FILE_RECEIVED`,
+  `ENDPOINT_DELETED`, `ENDPOINTS_LIST_CHANGED`, `AUTHORIZATION_ADDED`,
+  `AUTHORIZATION_REVOKED`.
+- `receive-endpoint-deleted-events` (alias `rede`) — `ENDPOINT_DELETED` only.
+- `receive-endpoints-list-changed-events` (alias `relc`) — `ENDPOINTS_LIST_CHANGED` only.
+- `receive-authorization-added-events` (alias `raa`) — `AUTHORIZATION_ADDED` only.
+- `receive-authorization-revoked-events` (alias `rar`) — `AUTHORIZATION_REVOKED` only.
+
+The dedicated single-type commands are thin wrappers around the same SSE
+stream `receive-events` uses; pick whichever reads more clearly in your
+workflow.
+
+### Interactive / web
+- `repl` — sandboxed interactive shell that re-invokes `art` for each line,
+  with tab completion for subcommands, flags and `$ART_*` env vars. Builtins:
+  `clear`, `exit`, `set-tenant <uuid>` (sets `$ART_TENANT_ID` for the session).
+- `serve` — minimal web UI on `http://localhost:8080` with the agrirouter
+  authorization flow, an endpoint-validation form, and an embedded xterm.js
+  terminal that runs `art repl`. Flags: `--port`, `--application-id`,
+  `--software-version-id`.
+
+## Typical session
+
+```bash
+export AGRIROUTER_OAUTH_CLIENT_ID=...
+export AGRIROUTER_OAUTH_CLIENT_SECRET=...
+export ART_APPLICATION_ID=00000000-0000-0000-0000-000000000000
+export ART_SOFTWARE_VERSION_ID=00000000-0000-0000-0000-000000000000
+export ART_TENANT_ID=00000000-0000-0000-0000-000000000000
+
+# Inspect what we currently see
+art list-authorized-tenants
+art list-tenant-endpoints
+
+# Stream every event type in one terminal
+art receive-events
+
+# Or stream just a subset
+art receive-events --types ENDPOINTS_LIST_CHANGED,AUTHORIZATION_ADDED
+
+# In another terminal, create an endpoint
+art put-endpoint \
+  --external-id urn:my-app:endpoint:demo \
+  --endpoint-type cloud_software \
+  --with-capability iso:11783:-10:taskdata:zip=SEND_RECEIVE
+```

--- a/examples/art/cmd/client.go
+++ b/examples/art/cmd/client.go
@@ -12,16 +12,31 @@ import (
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+const (
+	defaultAPIURL        = "https://api.qa.agrirouter.farm"
+	defaultOAuthTokenURL = "https://oauth.qa.agrirouter.farm/token"
+)
+
 func getClient(ctx context.Context) (*agrirouter.Client, error) {
+	apiURL := viper.GetString("ART_API_URL")
+	if apiURL == "" {
+		apiURL = defaultAPIURL
+	}
+	tokenURL := viper.GetString("ART_OAUTH_TOKEN_URL")
+	if tokenURL == "" {
+		tokenURL = defaultOAuthTokenURL
+	}
+
 	slog.Debug("Creating OAuth2 client using client credentials",
 		slog.String("client_id", viper.GetString("AGRIROUTER_OAUTH_CLIENT_ID")),
-		slog.String("token_url", "https://oauth.qa.agrirouter.farm/token"),
+		slog.String("token_url", tokenURL),
+		slog.String("api_url", apiURL),
 	)
 
 	clientCredsConfig := clientcredentials.Config{
 		ClientID:     viper.GetString("AGRIROUTER_OAUTH_CLIENT_ID"),
 		ClientSecret: viper.GetString("AGRIROUTER_OAUTH_CLIENT_SECRET"),
-		TokenURL:     "https://oauth.qa.agrirouter.farm/token",
+		TokenURL:     tokenURL,
 	}
 
 	tokenSource := clientCredsConfig.TokenSource(context.Background())
@@ -32,7 +47,7 @@ func getClient(ctx context.Context) (*agrirouter.Client, error) {
 
 	httpClient := oauth2.NewClient(ctx, tokenSource)
 	client, err := agrirouter.NewClient(
-		"https://api.qa.agrirouter.farm",
+		apiURL,
 		agrirouter.WithHTTPClient(httpClient),
 	)
 	if err != nil {

--- a/examples/art/cmd/listAuthorizedTenants.go
+++ b/examples/art/cmd/listAuthorizedTenants.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var listAuthorizedTenantsCmd = &cobra.Command{
+	Use:     "list-authorized-tenants",
+	Aliases: []string{"lat"},
+	Short:   "lists all tenants the application is authorized for, with their visible endpoints",
+	Long: `Calls GET /tenants and prints all authorized tenants together with the
+endpoints visible to the application in each tenant.
+
+This is intended as the primary global synchronization endpoint after
+application startup or recovery.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create agrirouter client: %w", err)
+		}
+
+		tenants, err := client.ListAuthorizedTenants(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list authorized tenants: %w", err)
+		}
+
+		fmt.Printf("Authorized tenants (%d):\n", len(tenants))
+		for _, tenant := range tenants {
+			fmt.Printf("- Tenant %s (%d endpoints):\n", tenant.TenantId, len(tenant.Endpoints))
+			for _, ep := range tenant.Endpoints {
+				printTenantEndpoint(ep, "    ")
+			}
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listAuthorizedTenantsCmd)
+}

--- a/examples/art/cmd/listTenantEndpoints.go
+++ b/examples/art/cmd/listTenantEndpoints.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/DKE-Data/agrirouter-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+var listTenantEndpointsCmd = &cobra.Command{
+	Use:     "list-tenant-endpoints",
+	Aliases: []string{"lte"},
+	Short:   "lists endpoints in one tenant with their capabilities and route information",
+	Long: `Calls GET /tenants/{tenantId}/endpoints and prints the current list of
+endpoints in the tenant together with their capabilities. Endpoints owned
+by the authorized application also include route-derived send/receive maps.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		tenantID, err := uuidFlagOrEnv(cmd, tenantIDOpt, "ART_TENANT_ID")
+		if err != nil {
+			return err
+		}
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create agrirouter client: %w", err)
+		}
+
+		endpoints, err := client.ListTenantEndpoints(ctx, tenantID)
+		if err != nil {
+			return fmt.Errorf("failed to list tenant endpoints: %w", err)
+		}
+
+		fmt.Printf("Endpoints in tenant %s (%d):\n", tenantID, len(endpoints))
+		for _, ep := range endpoints {
+			printTenantEndpoint(ep, "  ")
+		}
+		return nil
+	},
+}
+
+func printTenantEndpoint(ep agrirouter.TenantEndpointInfo, indent string) {
+	fmt.Printf("%s- %s (%s)\n", indent, ep.Name, ep.Id)
+	fmt.Printf("%s  Type: %s\n", indent, ep.EndpointType)
+	if ep.ExternalId != nil {
+		fmt.Printf("%s  ExternalID: %s\n", indent, *ep.ExternalId)
+	}
+	fmt.Printf("%s  ApplicationID: %s\n", indent, ep.ApplicationId)
+	fmt.Printf("%s  OwnedByYourApplication: %t\n", indent, ep.OwnedByYourApplication)
+	if len(ep.Capabilities.CanSend) > 0 {
+		fmt.Printf("%s  CanSend: %v\n", indent, ep.Capabilities.CanSend)
+	}
+	if len(ep.Capabilities.CanReceive) > 0 {
+		fmt.Printf("%s  CanReceive: %v\n", indent, ep.Capabilities.CanReceive)
+	}
+	if ep.RoutedEndpoints != nil {
+		if ep.RoutedEndpoints.CanSendTo != nil && len(*ep.RoutedEndpoints.CanSendTo) > 0 {
+			fmt.Printf("%s  CanSendTo:\n", indent)
+			for peerID, types := range *ep.RoutedEndpoints.CanSendTo {
+				fmt.Printf("%s    %s: %v\n", indent, peerID, types)
+			}
+		}
+		if ep.RoutedEndpoints.CanReceiveFrom != nil && len(*ep.RoutedEndpoints.CanReceiveFrom) > 0 {
+			fmt.Printf("%s  CanReceiveFrom:\n", indent)
+			for peerID, types := range *ep.RoutedEndpoints.CanReceiveFrom {
+				fmt.Printf("%s    %s: %v\n", indent, peerID, types)
+			}
+		}
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(listTenantEndpointsCmd)
+
+	listTenantEndpointsCmd.Flags().StringP(tenantIDOpt, "t", "", "ID of the tenant to list endpoints for (default: $ART_TENANT_ID)")
+}

--- a/examples/art/cmd/putEndpoint.go
+++ b/examples/art/cmd/putEndpoint.go
@@ -196,7 +196,6 @@ func init() {
 			agrirouter.CloudSoftware,
 		),
 	)
-	putEndpointCmd.MarkFlagRequired(endpointTypeOpt)
 	_ = putEndpointCmd.RegisterFlagCompletionFunc(endpointTypeOpt, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{
 			string(agrirouter.VirtualCommunicationUnit),

--- a/examples/art/cmd/receiveAuthorizationAddedEvents.go
+++ b/examples/art/cmd/receiveAuthorizationAddedEvents.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DKE-Data/agrirouter-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+var receiveAuthorizationAddedEventsCmd = &cobra.Command{
+	Use:     "receive-authorization-added-events",
+	Aliases: []string{"raa"},
+	Short:   "listens for AUTHORIZATION_ADDED events from the agrirouter",
+	Long: `Subscribes to the events stream and prints every AUTHORIZATION_ADDED
+event received. Each event carries the newly authorized tenant together
+with its currently visible endpoints.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create agrirouter client: %w", err)
+		}
+
+		err = client.ReceiveAuthorizationAddedEvents(ctx, func(ctx context.Context, event *agrirouter.AuthorizationAddedEventData) {
+			fmt.Printf("Authorization added:\n")
+			fmt.Printf("  TenantID: %s\n", event.Tenant.TenantId)
+			fmt.Printf("  Scope: %s\n", event.Scope)
+			fmt.Printf("  Endpoints (%d):\n", len(event.Tenant.Endpoints))
+			for _, ep := range event.Tenant.Endpoints {
+				printTenantEndpoint(ep, "    ")
+			}
+		}, func(err error) {
+			fmt.Printf("Error receiving authorization-added events: %v\n", err)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to receive authorization-added events: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(receiveAuthorizationAddedEventsCmd)
+}

--- a/examples/art/cmd/receiveAuthorizationRevokedEvents.go
+++ b/examples/art/cmd/receiveAuthorizationRevokedEvents.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DKE-Data/agrirouter-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+var receiveAuthorizationRevokedEventsCmd = &cobra.Command{
+	Use:     "receive-authorization-revoked-events",
+	Aliases: []string{"rar"},
+	Short:   "listens for AUTHORIZATION_REVOKED events from the agrirouter",
+	Long: `Subscribes to the events stream and prints every AUTHORIZATION_REVOKED
+event received. When this event arrives, access to the named tenant for
+the given scope has already been lost and any related local state should
+be cleaned up.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create agrirouter client: %w", err)
+		}
+
+		err = client.ReceiveAuthorizationRevokedEvents(ctx, func(ctx context.Context, event *agrirouter.AuthorizationRevokedEventData) {
+			fmt.Printf("Authorization revoked:\n")
+			fmt.Printf("  TenantID: %s\n", event.TenantId)
+			fmt.Printf("  Scope: %s\n", event.Scope)
+		}, func(err error) {
+			fmt.Printf("Error receiving authorization-revoked events: %v\n", err)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to receive authorization-revoked events: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(receiveAuthorizationRevokedEventsCmd)
+}

--- a/examples/art/cmd/receiveEndpointsListChangedEvents.go
+++ b/examples/art/cmd/receiveEndpointsListChangedEvents.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DKE-Data/agrirouter-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+var receiveEndpointsListChangedEventsCmd = &cobra.Command{
+	Use:     "receive-endpoints-list-changed-events",
+	Aliases: []string{"relc"},
+	Short:   "listens for ENDPOINTS_LIST_CHANGED events from the agrirouter",
+	Long: `Subscribes to the events stream and prints every ENDPOINTS_LIST_CHANGED
+event received. Each event carries the complete current list of endpoints
+visible to the application in the affected tenant.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create agrirouter client: %w", err)
+		}
+
+		err = client.ReceiveEndpointsListChangedEvents(ctx, func(ctx context.Context, event *agrirouter.EndpointsListChangedEventData) {
+			fmt.Printf("Endpoints list changed in tenant %s (%d endpoints):\n", event.TenantId, len(event.Endpoints))
+			for _, ep := range event.Endpoints {
+				printTenantEndpoint(ep, "  ")
+			}
+		}, func(err error) {
+			fmt.Printf("Error receiving endpoints-list-changed events: %v\n", err)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to receive endpoints-list-changed events: %w", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(receiveEndpointsListChangedEventsCmd)
+}

--- a/examples/art/cmd/receiveEvents.go
+++ b/examples/art/cmd/receiveEvents.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DKE-Data/agrirouter-sdk-go"
+	"github.com/spf13/cobra"
+)
+
+const eventTypesOpt = "types"
+
+var allEventTypes = []agrirouter.EventType{
+	agrirouter.EventTypeMessageReceived,
+	agrirouter.EventTypeFileReceived,
+	agrirouter.EventTypeEndpointDeleted,
+	agrirouter.EventTypeEndpointsListChanged,
+	agrirouter.EventTypeAuthorizationAdded,
+	agrirouter.EventTypeAuthorizationRevoked,
+}
+
+var receiveEventsCmd = &cobra.Command{
+	Use:     "receive-events",
+	Aliases: []string{"re"},
+	Short:   "listens for events of any kind from the agrirouter",
+	Long: `Subscribes to the agrirouter events stream and prints every received event.
+
+If --types is omitted, all event types are streamed. Otherwise the stream is
+restricted to the listed types. Available types: MESSAGE_RECEIVED,
+FILE_RECEIVED, ENDPOINT_DELETED, ENDPOINTS_LIST_CHANGED, AUTHORIZATION_ADDED,
+AUTHORIZATION_REVOKED.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		rawTypes, err := cmd.Flags().GetStringSlice(eventTypesOpt)
+		if err != nil {
+			return fmt.Errorf("failed to get %s flag: %w", eventTypesOpt, err)
+		}
+
+		types, err := parseEventTypes(rawTypes)
+		if err != nil {
+			return err
+		}
+
+		client, err := getClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create agrirouter client: %w", err)
+		}
+
+		handlers := agrirouter.EventHandlers{
+			OnMessage: func(ctx context.Context, message *agrirouter.Message) {
+				fmt.Printf("[MESSAGE_RECEIVED]\n")
+				fmt.Printf("  MessageID: %s\n", message.ID)
+				fmt.Printf("  AppMessageID: %s\n", message.AppMessageID)
+				fmt.Printf("  Type: %s\n", message.MessageType)
+				fmt.Printf("  ReceivingEndpointID: %s\n", message.ReceivingEndpointID)
+				fmt.Printf("  PayloadSize: %d bytes\n", len(message.Payload))
+			},
+			OnFile: func(ctx context.Context, file *agrirouter.File) {
+				fmt.Printf("[FILE_RECEIVED]\n")
+				fmt.Printf("  Type: %s\n", file.MessageType)
+				fmt.Printf("  ReceivingEndpointID: %s\n", file.ReceivingEndpointID)
+				fmt.Printf("  Size: %d bytes\n", file.Size)
+				fmt.Printf("  MessageIDs: %v\n", file.MessageIDs)
+			},
+			OnEndpointDeleted: func(ctx context.Context, deletion *agrirouter.DeletedEndpoint) {
+				fmt.Printf("[ENDPOINT_DELETED]\n")
+				fmt.Printf("  ID: %s\n", deletion.ID)
+				fmt.Printf("  ExternalID: %s\n", deletion.ExternalID)
+			},
+			OnEndpointsListChanged: func(ctx context.Context, event *agrirouter.EndpointsListChangedEventData) {
+				fmt.Printf("[ENDPOINTS_LIST_CHANGED] tenant %s, %d endpoints:\n", event.TenantId, len(event.Endpoints))
+				for _, ep := range event.Endpoints {
+					printTenantEndpoint(ep, "  ")
+				}
+			},
+			OnAuthorizationAdded: func(ctx context.Context, event *agrirouter.AuthorizationAddedEventData) {
+				fmt.Printf("[AUTHORIZATION_ADDED] tenant %s, scope %s, %d endpoints:\n",
+					event.Tenant.TenantId, event.Scope, len(event.Tenant.Endpoints))
+				for _, ep := range event.Tenant.Endpoints {
+					printTenantEndpoint(ep, "  ")
+				}
+			},
+			OnAuthorizationRevoked: func(ctx context.Context, event *agrirouter.AuthorizationRevokedEventData) {
+				fmt.Printf("[AUTHORIZATION_REVOKED] tenant %s, scope %s\n", event.TenantId, event.Scope)
+			},
+		}
+
+		err = client.ReceiveEvents(ctx, types, handlers, func(err error) {
+			fmt.Printf("Error receiving events: %v\n", err)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to receive events: %w", err)
+		}
+		return nil
+	},
+}
+
+func parseEventTypes(raw []string) ([]agrirouter.EventType, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	valid := make(map[string]agrirouter.EventType, len(allEventTypes))
+	for _, t := range allEventTypes {
+		valid[string(t)] = t
+	}
+	out := make([]agrirouter.EventType, 0, len(raw))
+	for _, r := range raw {
+		t, ok := valid[strings.ToUpper(strings.TrimSpace(r))]
+		if !ok {
+			return nil, fmt.Errorf("invalid event type %q (valid: %s)", r, joinEventTypes(allEventTypes))
+		}
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func joinEventTypes(types []agrirouter.EventType) string {
+	s := make([]string, len(types))
+	for i, t := range types {
+		s[i] = string(t)
+	}
+	return strings.Join(s, ", ")
+}
+
+func init() {
+	rootCmd.AddCommand(receiveEventsCmd)
+
+	receiveEventsCmd.Flags().StringSlice(eventTypesOpt, nil,
+		"Event types to receive. Comma-separated or repeated --types. If omitted, all event types are streamed.")
+	_ = receiveEventsCmd.RegisterFlagCompletionFunc(eventTypesOpt, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		out := make([]string, len(allEventTypes))
+		for i, t := range allEventTypes {
+			out[i] = string(t)
+		}
+		return out, cobra.ShellCompDirectiveNoFileComp
+	})
+}

--- a/examples/art/cmd/repl.go
+++ b/examples/art/cmd/repl.go
@@ -18,14 +18,26 @@ import (
 // 'repl' are excluded to keep the sandbox non-recursive; 'completion' is
 // excluded because it prints shell scripts that are useless inside the repl.
 var replAllowed = map[string]bool{
-	"put-endpoint":                    true,
-	"delete-endpoint":                 true,
-	"send-messages":                   true,
-	"receive-messages":                true,
-	"receive-endpoint-deleted-events": true,
-	"rede":                            true,
-	"confirm-messages":                true,
-	"help":                            true,
+	"put-endpoint":                           true,
+	"delete-endpoint":                        true,
+	"send-messages":                          true,
+	"receive-messages":                       true,
+	"receive-events":                         true,
+	"re":                                     true,
+	"receive-endpoint-deleted-events":        true,
+	"rede":                                   true,
+	"receive-endpoints-list-changed-events":  true,
+	"relc":                                   true,
+	"receive-authorization-added-events":     true,
+	"raa":                                    true,
+	"receive-authorization-revoked-events":   true,
+	"rar":                                    true,
+	"list-authorized-tenants":                true,
+	"lat":                                    true,
+	"list-tenant-endpoints":                  true,
+	"lte":                                    true,
+	"confirm-messages":                       true,
+	"help":                                   true,
 }
 
 var replCmd = &cobra.Command{

--- a/examples/art/cmd/root.go
+++ b/examples/art/cmd/root.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/subosito/gotenv"
 )
 
 var rootCmd = &cobra.Command{
@@ -15,7 +19,12 @@ var rootCmd = &cobra.Command{
 agrirouter G4 is a new API gateway allowing broader access to agrirouter.
 'art' is a simple command line tool demonstrating the usage of
 the agrirouter-sdk-go to interact with agrirouter. It can be useful
-by itself in order to test and debug agrirouter via G4 API.`,
+by itself in order to test and debug agrirouter via G4 API.
+
+Configuration values (AGRIROUTER_OAUTH_*, ART_*) are read from the process
+environment, which is automatically populated from a '.env' file in the
+current working directory if one exists. Existing environment values are
+not overridden by the file.`,
 	SilenceUsage: true,
 }
 
@@ -26,6 +35,16 @@ func Execute() {
 	}
 }
 
+// loadDotenv reads .env from the current working directory and exports each
+// variable that is not already set in the environment. It is intentionally
+// silent when the file is missing.
+func loadDotenv() {
+	if err := gotenv.Load(".env"); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		fmt.Fprintf(os.Stderr, "warning: failed to read .env: %v\n", err)
+	}
+}
+
 func init() {
+	loadDotenv()
 	viper.AutomaticEnv()
 }

--- a/examples/art/go.mod
+++ b/examples/art/go.mod
@@ -6,20 +6,21 @@ replace github.com/DKE-Data/agrirouter-sdk-go => ../..
 
 require (
 	github.com/DKE-Data/agrirouter-sdk-go v0.0.0-00010101000000-000000000000
+	github.com/chzyer/readline v1.5.1
+	github.com/creack/pty v1.1.24
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
+	github.com/subosito/gotenv v1.6.0
 	golang.org/x/oauth2 v0.30.0
 )
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/chzyer/readline v1.5.1 // indirect
-	github.com/creack/pty v1.1.24 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
@@ -28,7 +29,6 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
-	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tmaxmax/go-sse v0.11.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/examples/art/go.sum
+++ b/examples/art/go.sum
@@ -10,9 +10,11 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=

--- a/internal/oapi/models/oapi.models.go
+++ b/internal/oapi/models/oapi.models.go
@@ -33,10 +33,63 @@ const (
 
 // Defines values for ReceiveEventsParamsTypes.
 const (
-	ENDPOINTDELETED ReceiveEventsParamsTypes = "ENDPOINT_DELETED"
-	FILERECEIVED    ReceiveEventsParamsTypes = "FILE_RECEIVED"
-	MESSAGERECEIVED ReceiveEventsParamsTypes = "MESSAGE_RECEIVED"
+	AUTHORIZATIONADDED   ReceiveEventsParamsTypes = "AUTHORIZATION_ADDED"
+	AUTHORIZATIONREVOKED ReceiveEventsParamsTypes = "AUTHORIZATION_REVOKED"
+	ENDPOINTDELETED      ReceiveEventsParamsTypes = "ENDPOINT_DELETED"
+	ENDPOINTSLISTCHANGED ReceiveEventsParamsTypes = "ENDPOINTS_LIST_CHANGED"
+	FILERECEIVED         ReceiveEventsParamsTypes = "FILE_RECEIVED"
+	MESSAGERECEIVED      ReceiveEventsParamsTypes = "MESSAGE_RECEIVED"
 )
+
+// AuthorizationAddedEventData Data structure for AUTHORIZATION_ADDED events. This event would arrive
+// whenever a user adds an authorization for a tenant to the current
+// application.
+//
+// An authorization is uniquely identified by the triple
+// (tenant_id, application_id, scope). The application_id is implicit from
+// the receiving subscription; tenant_id and scope are explicit on this
+// event. At present the only scope in use is `endpoints:manage`;
+// additional scopes may be added in the future, and clients should then
+// treat authorizations with different scopes as distinct authorizations
+// even when tenant_id matches.
+type AuthorizationAddedEventData struct {
+	EventType string `json:"event_type"`
+
+	// Scope The OAuth scope that was granted with this authorization. Today
+	// the only scope in use is `endpoints:manage`; additional scopes may
+	// be introduced in future revisions of this API.
+	Scope  string     `json:"scope"`
+	Tenant TenantInfo `json:"tenant"`
+}
+
+// AuthorizationRevokedEventData Data structure for AUTHORIZATION_REVOKED events. This event would
+// arrive whenever a user revokes an authorization for a tenant from the
+// current application. When this event is delivered to you, you have
+// already lost access to the target tenant for the given scope. You
+// should clean up all information related to this tenant (for that scope)
+// and update your state accordingly.
+//
+// All endpoints that were previously accessible via this authorization
+// are considered removed. You will receive distinct ENDPOINT_DELETED
+// events for all endpoints deleted as a result of the authorization
+// revocation.
+//
+// Authorizations are uniquely identified by
+// (tenant_id, application_id, scope); only the authorization matching the
+// `scope` below was revoked. At present only the `endpoints:manage`
+// scope is in use, but if additional scopes are introduced later, other
+// scopes for the same tenant would remain in effect.
+type AuthorizationRevokedEventData struct {
+	EventType string `json:"event_type"`
+
+	// Scope The OAuth scope of the authorization that was revoked. Today the
+	// only scope in use is `endpoints:manage`; additional scopes may be
+	// introduced in future revisions of this API.
+	Scope string `json:"scope"`
+
+	// TenantId The tenant whose authorization was revoked.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
 
 // ConfirmMessagesRequest defines model for ConfirmMessagesRequest.
 type ConfirmMessagesRequest struct {
@@ -86,6 +139,10 @@ type EndpointDeletedEventData struct {
 	Id openapi_types.UUID `json:"id"`
 }
 
+// EndpointRouteMap Map keyed by agrirouter endpoint ID. Each value lists the message types
+// for which routing is currently possible between the two endpoints.
+type EndpointRouteMap map[string][]string
+
 // EndpointSubscription defines model for EndpointSubscription.
 type EndpointSubscription struct {
 	// MessageType The message type that the endpoint is subscribed to.
@@ -96,6 +153,31 @@ type EndpointSubscription struct {
 
 // EndpointType defines model for EndpointType.
 type EndpointType string
+
+// EndpointsListChangedEventData Data structure for ENDPOINTS_LIST_CHANGED events. This event would
+// arrive whenever the set of endpoints visible to the application, or
+// their respective capabilities and/or routes, change in a tenant.
+//
+// ENDPOINTS_LIST_CHANGED is only emitted once the application has at
+// least one endpoint of its own in the target tenant. Until that first
+// application-owned endpoint exists, changes to other endpoints in the
+// tenant are not reported, even if an authorization is in place. Once
+// the first own endpoint is created, clients receive events for any
+// subsequent change to the visible endpoint set.
+type EndpointsListChangedEventData struct {
+	// Endpoints Complete current list of endpoints in the tenant that are visible
+	// to the application.
+	Endpoints []TenantEndpointInfo `json:"endpoints"`
+	EventType string               `json:"event_type"`
+
+	// TenantId The tenant whose endpoint list changed.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
+
+// EndpointsListResponse defines model for EndpointsListResponse.
+type EndpointsListResponse struct {
+	Endpoints []TenantEndpointInfo `json:"endpoints"`
+}
 
 // ErrorResponse defines model for ErrorResponse.
 type ErrorResponse struct {
@@ -251,8 +333,92 @@ type PutEndpointRequest struct {
 	Subscriptions     []EndpointSubscription `json:"subscriptions"`
 }
 
+// RoutedEndpoints Route-derived information for this endpoint.
+//
+// This property only exists for endpoints owned by the authorized
+// application. It is omitted for all other endpoints in the tenant.
+type RoutedEndpoints struct {
+	// CanReceiveFrom Map keyed by agrirouter endpoint ID. Each value lists the message types
+	// for which routing is currently possible between the two endpoints.
+	CanReceiveFrom *EndpointRouteMap `json:"can_receive_from,omitempty"`
+
+	// CanSendTo Map keyed by agrirouter endpoint ID. Each value lists the message types
+	// for which routing is currently possible between the two endpoints.
+	CanSendTo *EndpointRouteMap `json:"can_send_to,omitempty"`
+}
+
+// TenantEndpointCapabilities defines model for TenantEndpointCapabilities.
+type TenantEndpointCapabilities struct {
+	// CanReceive Message types this endpoint can receive.
+	CanReceive []string `json:"can_receive"`
+
+	// CanSend Message types this endpoint can send.
+	CanSend []string `json:"can_send"`
+}
+
+// TenantEndpointInfo defines model for TenantEndpointInfo.
+type TenantEndpointInfo struct {
+	// ApplicationId The ID of the application that owns the endpoint.
+	ApplicationId openapi_types.UUID         `json:"application_id"`
+	Capabilities  TenantEndpointCapabilities `json:"capabilities"`
+	EndpointType  EndpointType               `json:"endpoint_type"`
+
+	// ExternalId External identifier of the endpoint, if available to the caller.
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Id The agrirouter endpoint ID.
+	Id openapi_types.UUID `json:"id"`
+
+	// Name Display name of the endpoint.
+	Name string `json:"name"`
+
+	// OwnedByYourApplication Indicates whether this endpoint belongs to the application that is authorized for the current request.
+	OwnedByYourApplication bool `json:"owned_by_your_application"`
+
+	// RoutedEndpoints Route-derived information for this endpoint.
+	//
+	// This property only exists for endpoints owned by the authorized
+	// application. It is omitted for all other endpoints in the tenant.
+	RoutedEndpoints *RoutedEndpoints `json:"routed_endpoints,omitempty"`
+
+	// TenantId The tenant ID of the endpoint.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
+
+// TenantInfo defines model for TenantInfo.
+type TenantInfo struct {
+	// Endpoints Endpoints visible in this tenant, subject to the following
+	// privacy rule:
+	//
+	// - If the application has not yet created any endpoint of its own
+	//   in this tenant, this array is empty — even if other endpoints
+	//   exist in the tenant. This prevents exposing tenant contents to
+	//   applications that have not yet actively participated in it.
+	// - Once the application has at least one of its own endpoints in
+	//   the tenant, this array contains the full set of endpoints
+	//   visible to the application.
+	//
+	// An authorized tenant with no application-owned endpoint will
+	// therefore still appear in `GET /tenants`, but with an empty
+	// `endpoints` array. See `owned_by_your_application` on
+	// `TenantEndpointInfo` for the distinction between own and other
+	// endpoints.
+	Endpoints []TenantEndpointInfo `json:"endpoints"`
+
+	// TenantId Authorized tenant ID.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
+
+// TenantsListResponse defines model for TenantsListResponse.
+type TenantsListResponse struct {
+	Tenants []TenantInfo `json:"tenants"`
+}
+
 // ExternalId defines model for externalId.
 type ExternalId = string
+
+// TenantId defines model for tenantId.
+type TenantId = openapi_types.UUID
 
 // XAgrirouterTenantId defines model for x-agrirouter-tenant-id.
 type XAgrirouterTenantId = openapi_types.UUID
@@ -426,6 +592,90 @@ func (t *GenericEventData) MergeEndpointDeletedEventData(v EndpointDeletedEventD
 	return err
 }
 
+// AsEndpointsListChangedEventData returns the union data inside the GenericEventData as a EndpointsListChangedEventData
+func (t GenericEventData) AsEndpointsListChangedEventData() (EndpointsListChangedEventData, error) {
+	var body EndpointsListChangedEventData
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromEndpointsListChangedEventData overwrites any union data inside the GenericEventData as the provided EndpointsListChangedEventData
+func (t *GenericEventData) FromEndpointsListChangedEventData(v EndpointsListChangedEventData) error {
+	v.EventType = "EndpointsListChangedEventData"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeEndpointsListChangedEventData performs a merge with any union data inside the GenericEventData, using the provided EndpointsListChangedEventData
+func (t *GenericEventData) MergeEndpointsListChangedEventData(v EndpointsListChangedEventData) error {
+	v.EventType = "EndpointsListChangedEventData"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsAuthorizationAddedEventData returns the union data inside the GenericEventData as a AuthorizationAddedEventData
+func (t GenericEventData) AsAuthorizationAddedEventData() (AuthorizationAddedEventData, error) {
+	var body AuthorizationAddedEventData
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAuthorizationAddedEventData overwrites any union data inside the GenericEventData as the provided AuthorizationAddedEventData
+func (t *GenericEventData) FromAuthorizationAddedEventData(v AuthorizationAddedEventData) error {
+	v.EventType = "AuthorizationAddedEventData"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAuthorizationAddedEventData performs a merge with any union data inside the GenericEventData, using the provided AuthorizationAddedEventData
+func (t *GenericEventData) MergeAuthorizationAddedEventData(v AuthorizationAddedEventData) error {
+	v.EventType = "AuthorizationAddedEventData"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsAuthorizationRevokedEventData returns the union data inside the GenericEventData as a AuthorizationRevokedEventData
+func (t GenericEventData) AsAuthorizationRevokedEventData() (AuthorizationRevokedEventData, error) {
+	var body AuthorizationRevokedEventData
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAuthorizationRevokedEventData overwrites any union data inside the GenericEventData as the provided AuthorizationRevokedEventData
+func (t *GenericEventData) FromAuthorizationRevokedEventData(v AuthorizationRevokedEventData) error {
+	v.EventType = "AuthorizationRevokedEventData"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAuthorizationRevokedEventData performs a merge with any union data inside the GenericEventData, using the provided AuthorizationRevokedEventData
+func (t *GenericEventData) MergeAuthorizationRevokedEventData(v AuthorizationRevokedEventData) error {
+	v.EventType = "AuthorizationRevokedEventData"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t GenericEventData) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"event_type"`
@@ -440,8 +690,14 @@ func (t GenericEventData) ValueByDiscriminator() (interface{}, error) {
 		return nil, err
 	}
 	switch discriminator {
+	case "AuthorizationAddedEventData":
+		return t.AsAuthorizationAddedEventData()
+	case "AuthorizationRevokedEventData":
+		return t.AsAuthorizationRevokedEventData()
 	case "EndpointDeletedEventData":
 		return t.AsEndpointDeletedEventData()
+	case "EndpointsListChangedEventData":
+		return t.AsEndpointsListChangedEventData()
 	case "FileReceivedEventData":
 		return t.AsFileReceivedEventData()
 	case "MessageReceivedEventData":

--- a/internal/oapi/oapi.client.go
+++ b/internal/oapi/oapi.client.go
@@ -108,6 +108,12 @@ type ClientInterface interface {
 
 	// SendMessagesWithBody request with any body
 	SendMessagesWithBody(ctx context.Context, params *SendMessagesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListAuthorizedTenants request
+	ListAuthorizedTenants(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListTenantEndpoints request
+	ListTenantEndpoints(ctx context.Context, tenantId TenantId, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) ConfirmMessagesWithBody(ctx context.Context, params *ConfirmMessagesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -184,6 +190,30 @@ func (c *Client) ReceiveEvents(ctx context.Context, params *ReceiveEventsParams,
 
 func (c *Client) SendMessagesWithBody(ctx context.Context, params *SendMessagesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSendMessagesRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListAuthorizedTenants(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAuthorizedTenantsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListTenantEndpoints(ctx context.Context, tenantId TenantId, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListTenantEndpointsRequest(c.Server, tenantId)
 	if err != nil {
 		return nil, err
 	}
@@ -532,6 +562,67 @@ func NewSendMessagesRequestWithBody(server string, params *SendMessagesParams, c
 	return req, nil
 }
 
+// NewListAuthorizedTenantsRequest generates requests for ListAuthorizedTenants
+func NewListAuthorizedTenantsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tenants")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListTenantEndpointsRequest generates requests for ListTenantEndpoints
+func NewListTenantEndpointsRequest(server string, tenantId TenantId) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "tenantId", runtime.ParamLocationPath, tenantId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tenants/%s/endpoints", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -593,6 +684,12 @@ type ClientWithResponsesInterface interface {
 
 	// SendMessagesWithBodyWithResponse request with any body
 	SendMessagesWithBodyWithResponse(ctx context.Context, params *SendMessagesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SendMessagesResponse, error)
+
+	// ListAuthorizedTenantsWithResponse request
+	ListAuthorizedTenantsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAuthorizedTenantsResponse, error)
+
+	// ListTenantEndpointsWithResponse request
+	ListTenantEndpointsWithResponse(ctx context.Context, tenantId TenantId, reqEditors ...RequestEditorFn) (*ListTenantEndpointsResponse, error)
 }
 
 type ConfirmMessagesResponse struct {
@@ -717,6 +814,56 @@ func (r SendMessagesResponse) StatusCode() int {
 	return 0
 }
 
+type ListAuthorizedTenantsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TenantsListResponse
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON403      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ListAuthorizedTenantsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListAuthorizedTenantsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListTenantEndpointsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *EndpointsListResponse
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON403      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ListTenantEndpointsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListTenantEndpointsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // ConfirmMessagesWithBodyWithResponse request with arbitrary body returning *ConfirmMessagesResponse
 func (c *ClientWithResponses) ConfirmMessagesWithBodyWithResponse(ctx context.Context, params *ConfirmMessagesParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ConfirmMessagesResponse, error) {
 	rsp, err := c.ConfirmMessagesWithBody(ctx, params, contentType, body, reqEditors...)
@@ -776,6 +923,24 @@ func (c *ClientWithResponses) SendMessagesWithBodyWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParseSendMessagesResponse(rsp)
+}
+
+// ListAuthorizedTenantsWithResponse request returning *ListAuthorizedTenantsResponse
+func (c *ClientWithResponses) ListAuthorizedTenantsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAuthorizedTenantsResponse, error) {
+	rsp, err := c.ListAuthorizedTenants(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListAuthorizedTenantsResponse(rsp)
+}
+
+// ListTenantEndpointsWithResponse request returning *ListTenantEndpointsResponse
+func (c *ClientWithResponses) ListTenantEndpointsWithResponse(ctx context.Context, tenantId TenantId, reqEditors ...RequestEditorFn) (*ListTenantEndpointsResponse, error) {
+	rsp, err := c.ListTenantEndpoints(ctx, tenantId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListTenantEndpointsResponse(rsp)
 }
 
 // ParseConfirmMessagesResponse parses an HTTP response from a ConfirmMessagesWithResponse call
@@ -983,6 +1148,100 @@ func ParseSendMessagesResponse(rsp *http.Response) (*SendMessagesResponse, error
 			return nil, err
 		}
 		response.JSON413 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListAuthorizedTenantsResponse parses an HTTP response from a ListAuthorizedTenantsWithResponse call
+func ParseListAuthorizedTenantsResponse(rsp *http.Response) (*ListAuthorizedTenantsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListAuthorizedTenantsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TenantsListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListTenantEndpointsResponse parses an HTTP response from a ListTenantEndpointsWithResponse call
+func ParseListTenantEndpointsResponse(rsp *http.Response) (*ListTenantEndpointsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListTenantEndpointsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest EndpointsListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	}
 

--- a/internal/tests/test_server/oapi.server.go
+++ b/internal/tests/test_server/oapi.server.go
@@ -39,10 +39,63 @@ const (
 
 // Defines values for ReceiveEventsParamsTypes.
 const (
-	ENDPOINTDELETED ReceiveEventsParamsTypes = "ENDPOINT_DELETED"
-	FILERECEIVED    ReceiveEventsParamsTypes = "FILE_RECEIVED"
-	MESSAGERECEIVED ReceiveEventsParamsTypes = "MESSAGE_RECEIVED"
+	AUTHORIZATIONADDED   ReceiveEventsParamsTypes = "AUTHORIZATION_ADDED"
+	AUTHORIZATIONREVOKED ReceiveEventsParamsTypes = "AUTHORIZATION_REVOKED"
+	ENDPOINTDELETED      ReceiveEventsParamsTypes = "ENDPOINT_DELETED"
+	ENDPOINTSLISTCHANGED ReceiveEventsParamsTypes = "ENDPOINTS_LIST_CHANGED"
+	FILERECEIVED         ReceiveEventsParamsTypes = "FILE_RECEIVED"
+	MESSAGERECEIVED      ReceiveEventsParamsTypes = "MESSAGE_RECEIVED"
 )
+
+// AuthorizationAddedEventData Data structure for AUTHORIZATION_ADDED events. This event would arrive
+// whenever a user adds an authorization for a tenant to the current
+// application.
+//
+// An authorization is uniquely identified by the triple
+// (tenant_id, application_id, scope). The application_id is implicit from
+// the receiving subscription; tenant_id and scope are explicit on this
+// event. At present the only scope in use is `endpoints:manage`;
+// additional scopes may be added in the future, and clients should then
+// treat authorizations with different scopes as distinct authorizations
+// even when tenant_id matches.
+type AuthorizationAddedEventData struct {
+	EventType string `json:"event_type"`
+
+	// Scope The OAuth scope that was granted with this authorization. Today
+	// the only scope in use is `endpoints:manage`; additional scopes may
+	// be introduced in future revisions of this API.
+	Scope  string     `json:"scope"`
+	Tenant TenantInfo `json:"tenant"`
+}
+
+// AuthorizationRevokedEventData Data structure for AUTHORIZATION_REVOKED events. This event would
+// arrive whenever a user revokes an authorization for a tenant from the
+// current application. When this event is delivered to you, you have
+// already lost access to the target tenant for the given scope. You
+// should clean up all information related to this tenant (for that scope)
+// and update your state accordingly.
+//
+// All endpoints that were previously accessible via this authorization
+// are considered removed. You will receive distinct ENDPOINT_DELETED
+// events for all endpoints deleted as a result of the authorization
+// revocation.
+//
+// Authorizations are uniquely identified by
+// (tenant_id, application_id, scope); only the authorization matching the
+// `scope` below was revoked. At present only the `endpoints:manage`
+// scope is in use, but if additional scopes are introduced later, other
+// scopes for the same tenant would remain in effect.
+type AuthorizationRevokedEventData struct {
+	EventType string `json:"event_type"`
+
+	// Scope The OAuth scope of the authorization that was revoked. Today the
+	// only scope in use is `endpoints:manage`; additional scopes may be
+	// introduced in future revisions of this API.
+	Scope string `json:"scope"`
+
+	// TenantId The tenant whose authorization was revoked.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
 
 // ConfirmMessagesRequest defines model for ConfirmMessagesRequest.
 type ConfirmMessagesRequest struct {
@@ -92,6 +145,10 @@ type EndpointDeletedEventData struct {
 	Id openapi_types.UUID `json:"id"`
 }
 
+// EndpointRouteMap Map keyed by agrirouter endpoint ID. Each value lists the message types
+// for which routing is currently possible between the two endpoints.
+type EndpointRouteMap map[string][]string
+
 // EndpointSubscription defines model for EndpointSubscription.
 type EndpointSubscription struct {
 	// MessageType The message type that the endpoint is subscribed to.
@@ -102,6 +159,31 @@ type EndpointSubscription struct {
 
 // EndpointType defines model for EndpointType.
 type EndpointType string
+
+// EndpointsListChangedEventData Data structure for ENDPOINTS_LIST_CHANGED events. This event would
+// arrive whenever the set of endpoints visible to the application, or
+// their respective capabilities and/or routes, change in a tenant.
+//
+// ENDPOINTS_LIST_CHANGED is only emitted once the application has at
+// least one endpoint of its own in the target tenant. Until that first
+// application-owned endpoint exists, changes to other endpoints in the
+// tenant are not reported, even if an authorization is in place. Once
+// the first own endpoint is created, clients receive events for any
+// subsequent change to the visible endpoint set.
+type EndpointsListChangedEventData struct {
+	// Endpoints Complete current list of endpoints in the tenant that are visible
+	// to the application.
+	Endpoints []TenantEndpointInfo `json:"endpoints"`
+	EventType string               `json:"event_type"`
+
+	// TenantId The tenant whose endpoint list changed.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
+
+// EndpointsListResponse defines model for EndpointsListResponse.
+type EndpointsListResponse struct {
+	Endpoints []TenantEndpointInfo `json:"endpoints"`
+}
 
 // ErrorResponse defines model for ErrorResponse.
 type ErrorResponse struct {
@@ -257,8 +339,92 @@ type PutEndpointRequest struct {
 	Subscriptions     []EndpointSubscription `json:"subscriptions"`
 }
 
+// RoutedEndpoints Route-derived information for this endpoint.
+//
+// This property only exists for endpoints owned by the authorized
+// application. It is omitted for all other endpoints in the tenant.
+type RoutedEndpoints struct {
+	// CanReceiveFrom Map keyed by agrirouter endpoint ID. Each value lists the message types
+	// for which routing is currently possible between the two endpoints.
+	CanReceiveFrom *EndpointRouteMap `json:"can_receive_from,omitempty"`
+
+	// CanSendTo Map keyed by agrirouter endpoint ID. Each value lists the message types
+	// for which routing is currently possible between the two endpoints.
+	CanSendTo *EndpointRouteMap `json:"can_send_to,omitempty"`
+}
+
+// TenantEndpointCapabilities defines model for TenantEndpointCapabilities.
+type TenantEndpointCapabilities struct {
+	// CanReceive Message types this endpoint can receive.
+	CanReceive []string `json:"can_receive"`
+
+	// CanSend Message types this endpoint can send.
+	CanSend []string `json:"can_send"`
+}
+
+// TenantEndpointInfo defines model for TenantEndpointInfo.
+type TenantEndpointInfo struct {
+	// ApplicationId The ID of the application that owns the endpoint.
+	ApplicationId openapi_types.UUID         `json:"application_id"`
+	Capabilities  TenantEndpointCapabilities `json:"capabilities"`
+	EndpointType  EndpointType               `json:"endpoint_type"`
+
+	// ExternalId External identifier of the endpoint, if available to the caller.
+	ExternalId *string `json:"external_id,omitempty"`
+
+	// Id The agrirouter endpoint ID.
+	Id openapi_types.UUID `json:"id"`
+
+	// Name Display name of the endpoint.
+	Name string `json:"name"`
+
+	// OwnedByYourApplication Indicates whether this endpoint belongs to the application that is authorized for the current request.
+	OwnedByYourApplication bool `json:"owned_by_your_application"`
+
+	// RoutedEndpoints Route-derived information for this endpoint.
+	//
+	// This property only exists for endpoints owned by the authorized
+	// application. It is omitted for all other endpoints in the tenant.
+	RoutedEndpoints *RoutedEndpoints `json:"routed_endpoints,omitempty"`
+
+	// TenantId The tenant ID of the endpoint.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
+
+// TenantInfo defines model for TenantInfo.
+type TenantInfo struct {
+	// Endpoints Endpoints visible in this tenant, subject to the following
+	// privacy rule:
+	//
+	// - If the application has not yet created any endpoint of its own
+	//   in this tenant, this array is empty — even if other endpoints
+	//   exist in the tenant. This prevents exposing tenant contents to
+	//   applications that have not yet actively participated in it.
+	// - Once the application has at least one of its own endpoints in
+	//   the tenant, this array contains the full set of endpoints
+	//   visible to the application.
+	//
+	// An authorized tenant with no application-owned endpoint will
+	// therefore still appear in `GET /tenants`, but with an empty
+	// `endpoints` array. See `owned_by_your_application` on
+	// `TenantEndpointInfo` for the distinction between own and other
+	// endpoints.
+	Endpoints []TenantEndpointInfo `json:"endpoints"`
+
+	// TenantId Authorized tenant ID.
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
+
+// TenantsListResponse defines model for TenantsListResponse.
+type TenantsListResponse struct {
+	Tenants []TenantInfo `json:"tenants"`
+}
+
 // ExternalId defines model for externalId.
 type ExternalId = string
+
+// TenantId defines model for tenantId.
+type TenantId = openapi_types.UUID
 
 // XAgrirouterTenantId defines model for x-agrirouter-tenant-id.
 type XAgrirouterTenantId = openapi_types.UUID
@@ -432,6 +598,90 @@ func (t *GenericEventData) MergeEndpointDeletedEventData(v EndpointDeletedEventD
 	return err
 }
 
+// AsEndpointsListChangedEventData returns the union data inside the GenericEventData as a EndpointsListChangedEventData
+func (t GenericEventData) AsEndpointsListChangedEventData() (EndpointsListChangedEventData, error) {
+	var body EndpointsListChangedEventData
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromEndpointsListChangedEventData overwrites any union data inside the GenericEventData as the provided EndpointsListChangedEventData
+func (t *GenericEventData) FromEndpointsListChangedEventData(v EndpointsListChangedEventData) error {
+	v.EventType = "EndpointsListChangedEventData"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeEndpointsListChangedEventData performs a merge with any union data inside the GenericEventData, using the provided EndpointsListChangedEventData
+func (t *GenericEventData) MergeEndpointsListChangedEventData(v EndpointsListChangedEventData) error {
+	v.EventType = "EndpointsListChangedEventData"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsAuthorizationAddedEventData returns the union data inside the GenericEventData as a AuthorizationAddedEventData
+func (t GenericEventData) AsAuthorizationAddedEventData() (AuthorizationAddedEventData, error) {
+	var body AuthorizationAddedEventData
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAuthorizationAddedEventData overwrites any union data inside the GenericEventData as the provided AuthorizationAddedEventData
+func (t *GenericEventData) FromAuthorizationAddedEventData(v AuthorizationAddedEventData) error {
+	v.EventType = "AuthorizationAddedEventData"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAuthorizationAddedEventData performs a merge with any union data inside the GenericEventData, using the provided AuthorizationAddedEventData
+func (t *GenericEventData) MergeAuthorizationAddedEventData(v AuthorizationAddedEventData) error {
+	v.EventType = "AuthorizationAddedEventData"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsAuthorizationRevokedEventData returns the union data inside the GenericEventData as a AuthorizationRevokedEventData
+func (t GenericEventData) AsAuthorizationRevokedEventData() (AuthorizationRevokedEventData, error) {
+	var body AuthorizationRevokedEventData
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromAuthorizationRevokedEventData overwrites any union data inside the GenericEventData as the provided AuthorizationRevokedEventData
+func (t *GenericEventData) FromAuthorizationRevokedEventData(v AuthorizationRevokedEventData) error {
+	v.EventType = "AuthorizationRevokedEventData"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeAuthorizationRevokedEventData performs a merge with any union data inside the GenericEventData, using the provided AuthorizationRevokedEventData
+func (t *GenericEventData) MergeAuthorizationRevokedEventData(v AuthorizationRevokedEventData) error {
+	v.EventType = "AuthorizationRevokedEventData"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t GenericEventData) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"event_type"`
@@ -446,8 +696,14 @@ func (t GenericEventData) ValueByDiscriminator() (interface{}, error) {
 		return nil, err
 	}
 	switch discriminator {
+	case "AuthorizationAddedEventData":
+		return t.AsAuthorizationAddedEventData()
+	case "AuthorizationRevokedEventData":
+		return t.AsAuthorizationRevokedEventData()
 	case "EndpointDeletedEventData":
 		return t.AsEndpointDeletedEventData()
+	case "EndpointsListChangedEventData":
+		return t.AsEndpointsListChangedEventData()
 	case "FileReceivedEventData":
 		return t.AsFileReceivedEventData()
 	case "MessageReceivedEventData":
@@ -484,6 +740,12 @@ type ServerInterface interface {
 	// Send one or several messages to agrirouter inbox
 	// (POST /messages)
 	SendMessages(ctx echo.Context, params SendMessagesParams) error
+	// List all authorized tenants and their related endpoints
+	// (GET /tenants)
+	ListAuthorizedTenants(ctx echo.Context) error
+	// List tenant endpoints with route information
+	// (GET /tenants/{tenantId}/endpoints)
+	ListTenantEndpoints(ctx echo.Context, tenantId TenantId) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -814,6 +1076,39 @@ func (w *ServerInterfaceWrapper) SendMessages(ctx echo.Context) error {
 	return err
 }
 
+// ListAuthorizedTenants converts echo context to params.
+func (w *ServerInterfaceWrapper) ListAuthorizedTenants(ctx echo.Context) error {
+	var err error
+
+	ctx.Set(AgrirouterOauthQAScopes, []string{})
+
+	ctx.Set(AgrirouterOauthPRODScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ListAuthorizedTenants(ctx)
+	return err
+}
+
+// ListTenantEndpoints converts echo context to params.
+func (w *ServerInterfaceWrapper) ListTenantEndpoints(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "tenantId" -------------
+	var tenantId TenantId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "tenantId", ctx.Param("tenantId"), &tenantId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter tenantId: %s", err))
+	}
+
+	ctx.Set(AgrirouterOauthQAScopes, []string{})
+
+	ctx.Set(AgrirouterOauthPRODScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ListTenantEndpoints(ctx, tenantId)
+	return err
+}
+
 // This is a simple interface which specifies echo.Route addition functions which
 // are present on both echo.Echo and echo.Group, since we want to allow using
 // either of them for path registration
@@ -847,6 +1142,8 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.PUT(baseURL+"/endpoints/:externalId", wrapper.PutEndpoint)
 	router.GET(baseURL+"/events", wrapper.ReceiveEvents)
 	router.POST(baseURL+"/messages", wrapper.SendMessages)
+	router.GET(baseURL+"/tenants", wrapper.ListAuthorizedTenants)
+	router.GET(baseURL+"/tenants/:tenantId/endpoints", wrapper.ListTenantEndpoints)
 
 }
 
@@ -1179,6 +1476,109 @@ func (response SendMessages500Response) VisitSendMessagesResponse(w http.Respons
 	return nil
 }
 
+type ListAuthorizedTenantsRequestObject struct {
+}
+
+type ListAuthorizedTenantsResponseObject interface {
+	VisitListAuthorizedTenantsResponse(w http.ResponseWriter) error
+}
+
+type ListAuthorizedTenants200JSONResponse TenantsListResponse
+
+func (response ListAuthorizedTenants200JSONResponse) VisitListAuthorizedTenantsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListAuthorizedTenants400JSONResponse ErrorResponse
+
+func (response ListAuthorizedTenants400JSONResponse) VisitListAuthorizedTenantsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListAuthorizedTenants401JSONResponse ErrorResponse
+
+func (response ListAuthorizedTenants401JSONResponse) VisitListAuthorizedTenantsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListAuthorizedTenants403JSONResponse ErrorResponse
+
+func (response ListAuthorizedTenants403JSONResponse) VisitListAuthorizedTenantsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListAuthorizedTenants500Response struct {
+}
+
+func (response ListAuthorizedTenants500Response) VisitListAuthorizedTenantsResponse(w http.ResponseWriter) error {
+	w.WriteHeader(500)
+	return nil
+}
+
+type ListTenantEndpointsRequestObject struct {
+	TenantId TenantId `json:"tenantId"`
+}
+
+type ListTenantEndpointsResponseObject interface {
+	VisitListTenantEndpointsResponse(w http.ResponseWriter) error
+}
+
+type ListTenantEndpoints200JSONResponse EndpointsListResponse
+
+func (response ListTenantEndpoints200JSONResponse) VisitListTenantEndpointsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListTenantEndpoints400JSONResponse ErrorResponse
+
+func (response ListTenantEndpoints400JSONResponse) VisitListTenantEndpointsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListTenantEndpoints401JSONResponse ErrorResponse
+
+func (response ListTenantEndpoints401JSONResponse) VisitListTenantEndpointsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListTenantEndpoints403JSONResponse ErrorResponse
+
+func (response ListTenantEndpoints403JSONResponse) VisitListTenantEndpointsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListTenantEndpoints500Response struct {
+}
+
+func (response ListTenantEndpoints500Response) VisitListTenantEndpointsResponse(w http.ResponseWriter) error {
+	w.WriteHeader(500)
+	return nil
+}
+
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 	// Confirm received messages
@@ -1196,6 +1596,12 @@ type StrictServerInterface interface {
 	// Send one or several messages to agrirouter inbox
 	// (POST /messages)
 	SendMessages(ctx context.Context, request SendMessagesRequestObject) (SendMessagesResponseObject, error)
+	// List all authorized tenants and their related endpoints
+	// (GET /tenants)
+	ListAuthorizedTenants(ctx context.Context, request ListAuthorizedTenantsRequestObject) (ListAuthorizedTenantsResponseObject, error)
+	// List tenant endpoints with route information
+	// (GET /tenants/{tenantId}/endpoints)
+	ListTenantEndpoints(ctx context.Context, request ListTenantEndpointsRequestObject) (ListTenantEndpointsResponseObject, error)
 }
 
 type StrictHandlerFunc = strictecho.StrictEchoHandlerFunc
@@ -1345,6 +1751,54 @@ func (sh *strictHandler) SendMessages(ctx echo.Context, params SendMessagesParam
 		return err
 	} else if validResponse, ok := response.(SendMessagesResponseObject); ok {
 		return validResponse.VisitSendMessagesResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// ListAuthorizedTenants operation middleware
+func (sh *strictHandler) ListAuthorizedTenants(ctx echo.Context) error {
+	var request ListAuthorizedTenantsRequestObject
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.ListAuthorizedTenants(ctx.Request().Context(), request.(ListAuthorizedTenantsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListAuthorizedTenants")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(ListAuthorizedTenantsResponseObject); ok {
+		return validResponse.VisitListAuthorizedTenantsResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// ListTenantEndpoints operation middleware
+func (sh *strictHandler) ListTenantEndpoints(ctx echo.Context, tenantId TenantId) error {
+	var request ListTenantEndpointsRequestObject
+
+	request.TenantId = tenantId
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.ListTenantEndpoints(ctx.Request().Context(), request.(ListTenantEndpointsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListTenantEndpoints")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(ListTenantEndpointsResponseObject); ok {
+		return validResponse.VisitListTenantEndpointsResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/internal/tests/test_server/testserver.go
+++ b/internal/tests/test_server/testserver.go
@@ -213,6 +213,14 @@ func (s *Server) SendMessages(ctx context.Context, request SendMessagesRequestOb
 	return SendMessages200Response{}, nil
 }
 
+func (s *Server) ListAuthorizedTenants(_ context.Context, _ ListAuthorizedTenantsRequestObject) (ListAuthorizedTenantsResponseObject, error) {
+	return ListAuthorizedTenants200JSONResponse{Tenants: []TenantInfo{}}, nil
+}
+
+func (s *Server) ListTenantEndpoints(_ context.Context, _ ListTenantEndpointsRequestObject) (ListTenantEndpointsResponseObject, error) {
+	return ListTenantEndpoints200JSONResponse{Endpoints: []TenantEndpointInfo{}}, nil
+}
+
 func (s *Server) ConfirmMessages(_ context.Context, request ConfirmMessagesRequestObject) (ConfirmMessagesResponseObject, error) {
 	dataBytes, err := json.Marshal(request.Body)
 	if err != nil {

--- a/models.go
+++ b/models.go
@@ -95,6 +95,39 @@ type MessageReceivedEventData = internal_models.MessageReceivedEventData
 // either via this API or by other means (e.g. user-initiated deletion from the agrirouter UI).
 type EndpointDeletedEventData = internal_models.EndpointDeletedEventData
 
+// EndpointsListChangedEventData represents the data received in an EndpointsListChanged event.
+//
+// It is emitted whenever the set of endpoints visible to the application,
+// or their respective capabilities and/or routes, change in a tenant.
+type EndpointsListChangedEventData = internal_models.EndpointsListChangedEventData
+
+// AuthorizationAddedEventData represents the data received in an AuthorizationAdded event.
+//
+// It is emitted whenever a user adds an authorization for a tenant to the
+// current application.
+type AuthorizationAddedEventData = internal_models.AuthorizationAddedEventData
+
+// AuthorizationRevokedEventData represents the data received in an AuthorizationRevoked event.
+//
+// It is emitted whenever a user revokes an authorization for a tenant from
+// the current application.
+type AuthorizationRevokedEventData = internal_models.AuthorizationRevokedEventData
+
+// TenantInfo describes an authorized tenant together with its visible endpoints.
+type TenantInfo = internal_models.TenantInfo
+
+// TenantEndpointInfo describes a single endpoint visible to the application within a tenant.
+type TenantEndpointInfo = internal_models.TenantEndpointInfo
+
+// TenantEndpointCapabilities describes the message types an endpoint can send or receive.
+type TenantEndpointCapabilities = internal_models.TenantEndpointCapabilities
+
+// RoutedEndpoints describes route-derived information for an application-owned endpoint.
+type RoutedEndpoints = internal_models.RoutedEndpoints
+
+// EndpointRouteMap is a map keyed by agrirouter endpoint ID, listing message types routable between two endpoints.
+type EndpointRouteMap = internal_models.EndpointRouteMap
+
 // EndpointType represents the type of an agrirouter endpoint.
 //
 // There are three main types of endpoints:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -178,7 +178,7 @@ paths:
           description: |
             Events type filter, if provided would limit the events returned to only those of the specified types.
             If not provided, all supported events will be streamed.
-          example: ["MESSAGE_RECEIVED", "FILE_RECEIVED"]
+          example: ["MESSAGE_RECEIVED", "FILE_RECEIVED", "AUTHORIZATION_ADDED"]
           schema:
             type: array
             items:
@@ -187,6 +187,9 @@ paths:
                 - MESSAGE_RECEIVED
                 - FILE_RECEIVED
                 - ENDPOINT_DELETED
+                - ENDPOINTS_LIST_CHANGED
+                - AUTHORIZATION_ADDED
+                - AUTHORIZATION_REVOKED
       description: |
         Receive stream of events from the agrirouter outbox.
         The events are retrieved for every endpoint of an
@@ -195,6 +198,10 @@ paths:
         These are possible event types:
         - MESSAGE_RECEIVED - when one message is received
         - FILE_RECEIVED - when chunked payload has been completely received
+        - ENDPOINT_DELETED - when one of the application's endpoints is deleted
+        - ENDPOINTS_LIST_CHANGED - when the list of endpoints in a tenant changes
+        - AUTHORIZATION_ADDED - when a tenant authorization is newly added
+        - AUTHORIZATION_REVOKED - when a tenant authorization is revoked
 
         These events are sent as Server-Sent Events (SSE), where one line
         prefixed "event:" would define event type and another line
@@ -204,7 +211,7 @@ paths:
         https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
 
         For example:
-        
+
         ```
         event: MESSAGE_RECEIVED
         data: {"messageId":"12345","timestamp":"2023-01-01T12:00:00Z"}
@@ -212,15 +219,18 @@ paths:
 
         In this API, `data` would always be JSON encoded object, every
         event data schema is defined in the `#/components/schemas`, with
-        schema name always ending with `EventData`. 
+        schema name always ending with `EventData`.
 
         Here is a table:
 
-        | Event Type          | Schema                                                                     |
-        |---------------------|----------------------------------------------------------------------------|
-        | MESSAGE_RECEIVED    | [MessageReceivedEventData](#/components/schemas/MessageReceivedEventData)  |
-        | FILE_RECEIVED       | [FileReceivedEventData](#/components/schemas/FileReceivedEventData)        |
-        | ENDPOINT_DELETED    | [EndpointDeletedEventData](#/components/schemas/EndpointDeletedEventData)  |
+        | Event Type             | Schema                                                                              |
+        |------------------------|-------------------------------------------------------------------------------------|
+        | MESSAGE_RECEIVED       | [MessageReceivedEventData](#/components/schemas/MessageReceivedEventData)           |
+        | FILE_RECEIVED          | [FileReceivedEventData](#/components/schemas/FileReceivedEventData)                 |
+        | ENDPOINT_DELETED       | [EndpointDeletedEventData](#/components/schemas/EndpointDeletedEventData)           |
+        | ENDPOINTS_LIST_CHANGED | [EndpointsListChangedEventData](#/components/schemas/EndpointsListChangedEventData) |
+        | AUTHORIZATION_ADDED    | [AuthorizationAddedEventData](#/components/schemas/AuthorizationAddedEventData)     |
+        | AUTHORIZATION_REVOKED  | [AuthorizationRevokedEventData](#/components/schemas/AuthorizationRevokedEventData) |
 
       # As there is no yet accepted way of defining schema for SSE data,
       # it would have to be only described in description for now.
@@ -260,6 +270,96 @@ paths:
       responses:
         '202':
           description: Confirmation is saved for processing, feed will be updated eventually
+        '400':
+          description: Request is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '403':
+          description: Authorization failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '500':
+          description: Server Side Error
+
+  /tenants/{tenantId}/endpoints:
+    get:
+      operationId: listTenantEndpoints
+      summary: List tenant endpoints with route information
+      description: |
+        Returns the current list of endpoints in the tenant together with their
+        capability information.
+
+        For endpoints owned by the authorized application, this operation also
+        returns route-derived maps describing which endpoints they can send to
+        and receive from for each message type.
+
+        This operation is tenant-scoped and is intended for inspecting or
+        refreshing endpoint information for one already-known tenant. Use it
+        for example if you cannot/do not want to persist information from the
+        `ENDPOINTS_LIST_CHANGED` event or if your frontend doesn't have access to
+        that data.
+
+        It is not intended as the primary application-start or global re-sync
+        operation. For that purpose, use `GET /tenants`, which returns all
+        currently authorized tenants together with their related endpoints.
+      parameters:
+        - $ref: "#/components/parameters/tenantId"
+      responses:
+        '200':
+          description: Tenant endpoints successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EndpointsListResponse"
+        '400':
+          description: Request is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '401':
+          description: Authentication failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '403':
+          description: Authorization failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        '500':
+          description: Server Side Error
+
+  /tenants:
+    get:
+      operationId: listAuthorizedTenants
+      summary: List all authorized tenants and their related endpoints
+      description: |
+        Returns all tenants for which the current application has an existing
+        authorization together with the related endpoints known for each tenant.
+
+        This operation is intended as the primary global synchronization
+        endpoint, for example when an application starts, recovers after a
+        crash, or otherwise needs to rebuild its complete tenant state.
+      responses:
+        '200':
+          description: Authorized tenants successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantsListResponse"
         '400':
           description: Request is invalid
           content:
@@ -412,6 +512,14 @@ components:
         type: string
         format: uuid
       description: The farmer's tenant ID in relation to which communication is done.
+    tenantId:
+      name: tenantId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: The farmer's tenant ID in relation to which this operation is performed.
     externalId:
       name: externalId
       in: path
@@ -435,6 +543,9 @@ components:
         - $ref: "#/components/schemas/MessageReceivedEventData"
         - $ref: "#/components/schemas/FileReceivedEventData"
         - $ref: "#/components/schemas/EndpointDeletedEventData"
+        - $ref: "#/components/schemas/EndpointsListChangedEventData"
+        - $ref: "#/components/schemas/AuthorizationAddedEventData"
+        - $ref: "#/components/schemas/AuthorizationRevokedEventData"
       discriminator:
         propertyName: event_type
     PayloadURI:
@@ -521,6 +632,233 @@ components:
         event_type:
           type: string
           const: ENDPOINT_DELETED
+    EndpointsListChangedEventData:
+      type: object
+      description: |
+        Data structure for ENDPOINTS_LIST_CHANGED events. This event would
+        arrive whenever the set of endpoints visible to the application, or
+        their respective capabilities and/or routes, change in a tenant.
+
+        ENDPOINTS_LIST_CHANGED is only emitted once the application has at
+        least one endpoint of its own in the target tenant. Until that first
+        application-owned endpoint exists, changes to other endpoints in the
+        tenant are not reported, even if an authorization is in place. Once
+        the first own endpoint is created, clients receive events for any
+        subsequent change to the visible endpoint set.
+      required:
+        - event_type
+        - tenant_id
+        - endpoints
+      properties:
+        event_type:
+          type: string
+          const: ENDPOINTS_LIST_CHANGED
+        tenant_id:
+          type: string
+          format: uuid
+          description: The tenant whose endpoint list changed.
+        endpoints:
+          type: array
+          description: |
+            Complete current list of endpoints in the tenant that are visible
+            to the application.
+          items:
+            $ref: "#/components/schemas/TenantEndpointInfo"
+    AuthorizationAddedEventData:
+      type: object
+      description: |
+        Data structure for AUTHORIZATION_ADDED events. This event would arrive
+        whenever a user adds an authorization for a tenant to the current
+        application.
+
+        An authorization is uniquely identified by the triple
+        (tenant_id, application_id, scope). The application_id is implicit from
+        the receiving subscription; tenant_id and scope are explicit on this
+        event. At present the only scope in use is `endpoints:manage`;
+        additional scopes may be added in the future, and clients should then
+        treat authorizations with different scopes as distinct authorizations
+        even when tenant_id matches.
+      required:
+        - event_type
+        - tenant
+        - scope
+      properties:
+        event_type:
+          type: string
+          const: AUTHORIZATION_ADDED
+        tenant:
+          $ref: "#/components/schemas/TenantInfo"
+        scope:
+          type: string
+          description: |
+            The OAuth scope that was granted with this authorization. Today
+            the only scope in use is `endpoints:manage`; additional scopes may
+            be introduced in future revisions of this API.
+          example: "endpoints:manage"
+    AuthorizationRevokedEventData:
+      type: object
+      description: |
+        Data structure for AUTHORIZATION_REVOKED events. This event would
+        arrive whenever a user revokes an authorization for a tenant from the
+        current application. When this event is delivered to you, you have
+        already lost access to the target tenant for the given scope. You
+        should clean up all information related to this tenant (for that scope)
+        and update your state accordingly.
+
+        All endpoints that were previously accessible via this authorization
+        are considered removed. You will receive distinct ENDPOINT_DELETED
+        events for all endpoints deleted as a result of the authorization
+        revocation.
+
+        Authorizations are uniquely identified by
+        (tenant_id, application_id, scope); only the authorization matching the
+        `scope` below was revoked. At present only the `endpoints:manage`
+        scope is in use, but if additional scopes are introduced later, other
+        scopes for the same tenant would remain in effect.
+      required:
+        - event_type
+        - tenant_id
+        - scope
+      properties:
+        event_type:
+          type: string
+          const: AUTHORIZATION_REVOKED
+        tenant_id:
+          type: string
+          format: uuid
+          description: The tenant whose authorization was revoked.
+        scope:
+          type: string
+          description: |
+            The OAuth scope of the authorization that was revoked. Today the
+            only scope in use is `endpoints:manage`; additional scopes may be
+            introduced in future revisions of this API.
+          example: "endpoints:manage"
+    EndpointsListResponse:
+      type: object
+      required:
+        - endpoints
+      properties:
+        endpoints:
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantEndpointInfo"
+    TenantsListResponse:
+      type: object
+      required:
+        - tenants
+      properties:
+        tenants:
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantInfo"
+    TenantInfo:
+      type: object
+      required:
+        - tenant_id
+        - endpoints
+      properties:
+        tenant_id:
+          type: string
+          format: uuid
+          description: Authorized tenant ID.
+        endpoints:
+          type: array
+          description: |
+            Endpoints visible in this tenant, subject to the following
+            privacy rule:
+
+            - If the application has not yet created any endpoint of its own
+              in this tenant, this array is empty — even if other endpoints
+              exist in the tenant. This prevents exposing tenant contents to
+              applications that have not yet actively participated in it.
+            - Once the application has at least one of its own endpoints in
+              the tenant, this array contains the full set of endpoints
+              visible to the application.
+
+            An authorized tenant with no application-owned endpoint will
+            therefore still appear in `GET /tenants`, but with an empty
+            `endpoints` array. See `owned_by_your_application` on
+            `TenantEndpointInfo` for the distinction between own and other
+            endpoints.
+          items:
+            $ref: "#/components/schemas/TenantEndpointInfo"
+    TenantEndpointInfo:
+      type: object
+      required:
+        - id
+        - name
+        - endpoint_type
+        - application_id
+        - tenant_id
+        - owned_by_your_application
+        - capabilities
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: The agrirouter endpoint ID.
+        external_id:
+          type: string
+          description: External identifier of the endpoint, if available to the caller.
+        name:
+          type: string
+          description: Display name of the endpoint.
+        endpoint_type:
+          $ref: "#/components/schemas/EndpointType"
+        application_id:
+          type: string
+          format: uuid
+          description: The ID of the application that owns the endpoint.
+        tenant_id:
+          type: string
+          format: uuid
+          description: The tenant ID of the endpoint.
+        owned_by_your_application:
+          type: boolean
+          description: Indicates whether this endpoint belongs to the application that is authorized for the current request.
+        capabilities:
+          $ref: "#/components/schemas/TenantEndpointCapabilities"
+        routed_endpoints:
+          $ref: "#/components/schemas/RoutedEndpoints"
+    TenantEndpointCapabilities:
+      type: object
+      required:
+        - can_send
+        - can_receive
+      properties:
+        can_send:
+          type: array
+          description: Message types this endpoint can send.
+          items:
+            type: string
+        can_receive:
+          type: array
+          description: Message types this endpoint can receive.
+          items:
+            type: string
+    RoutedEndpoints:
+      type: object
+      description: |
+        Route-derived information for this endpoint.
+
+        This property only exists for endpoints owned by the authorized
+        application. It is omitted for all other endpoints in the tenant.
+      properties:
+        can_send_to:
+          $ref: "#/components/schemas/EndpointRouteMap"
+        can_receive_from:
+          $ref: "#/components/schemas/EndpointRouteMap"
+    EndpointRouteMap:
+      type: object
+      description: |
+        Map keyed by agrirouter endpoint ID. Each value lists the message types
+        for which routing is currently possible between the two endpoints.
+      additionalProperties:
+        type: array
+        items:
+          type: string
+          example: "iso:11783:-10:taskdata:zip"
     FileReceivedEventData:
       type: object
       description: |


### PR DESCRIPTION
Sync openapi spec with gateway: add ENDPOINTS_LIST_CHANGED, AUTHORIZATION_ADDED, AUTHORIZATION_REVOKED events plus GET /tenants and GET /tenants/{tenantId}/endpoints. Expose ListAuthorizedTenants and ListTenantEndpoints on the SDK client and add per-event listeners plus a generic ReceiveEvents with optional type filter.

In the art example: add list-authorized-tenants, list-tenant-endpoints, receive-events (and per-type variants), .env loading via gotenv, a README with the env-var reference, .env.example, and ART_API_URL / ART_OAUTH_TOKEN_URL overrides for pointing at a local gateway.